### PR TITLE
Flakify

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,4 +1,4 @@
-name: "nix-build"
+name: "nix build"
 
 on:
   push:
@@ -13,5 +13,5 @@ jobs:
     - uses: actions/checkout@v3
     - uses: cachix/install-nix-action@v22
       with:
-        nix_path: nixpkgs=channel:nixos-unstable
-    - run: nix-build
+        nix_path: nixpkgs=channel:nixos-23.11
+    - run: nix build

--- a/default.nix
+++ b/default.nix
@@ -1,22 +1,13 @@
-{ pkgs ? import <nixpkgs> { } }:
-
+{
+  pkgs,
+  rpki-client-src,
+  rpki-openbsd-src,
+}:
 pkgs.stdenv.mkDerivation rec {
   name = "rpki-client";
-  version = "8.2";
+  version = "8.6";
 
-  src = pkgs.fetchFromGitHub {
-    owner = "rpki-client";
-    repo = "rpki-client-portable";
-    rev = version;
-    hash = "sha256-oErUjZn/a/Ka70+Z8Wb2L7UIulGPjF81bYAQ2wPvWfo=";
-  };
-
-  openbsd_src = pkgs.fetchFromGitHub {
-    owner = "rpki-client";
-    repo = "rpki-client-openbsd";
-    rev = "rpki-client-8.2";
-    hash = "sha256-zC3vbQLLWgImS+lYNWbHzkLrZTJvgPfH+W+FiSnH8Aw=";
-  };
+  src = rpki-client-src;
 
   buildInputs = with pkgs; [
     libressl
@@ -25,11 +16,12 @@ pkgs.stdenv.mkDerivation rec {
     autoconf
     libtool
     rsync
+    zlib
   ];
 
   unpackPhase = ''
     mkdir -p openbsd
-    cp -R ${openbsd_src}/* openbsd
+    cp -R ${rpki-openbsd-src}/* openbsd
     cp -R ${src}/* .
     chmod 700 -R .
   '';

--- a/default.nix
+++ b/default.nix
@@ -3,12 +3,14 @@
   rpki-client-src,
   rpki-openbsd-src,
 }:
+# build the package
 pkgs.stdenv.mkDerivation rec {
   name = "rpki-client";
   version = "8.6";
 
   src = rpki-client-src;
 
+  # Dependencies required at build time
   buildInputs = with pkgs; [
     libressl
     expat
@@ -19,6 +21,9 @@ pkgs.stdenv.mkDerivation rec {
     zlib
   ];
 
+  # Prepare the source directory before configuring and building.
+  # In this case, we set up the openbsd directory, which rpki-client-portable expects,
+  # with the rpki-openbsd-src attribute we set up as a flake input.
   unpackPhase = ''
     mkdir -p openbsd
     cp -R ${rpki-openbsd-src}/* openbsd
@@ -26,8 +31,13 @@ pkgs.stdenv.mkDerivation rec {
     chmod 700 -R .
   '';
 
+  # Configure with the given scripts, but point to our nix-specific $out directory
   configurePhase = ''
     ./autogen.sh
     ./configure --prefix=$out
   '';
+
+  # The default buildPhase for stdenv.mkDerivation is "make"
+  # which is what the project wants in this case.
+  # So we don't need to modify the buildPhase.
 }

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1700403855,
-        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
+        "lastModified": 1701156937,
+        "narHash": "sha256-jpMJOFvOTejx211D8z/gz0ErRtQPy6RXxgD2ZB86mso=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
+        "rev": "7c4c20509c4363195841faa6c911777a134acdf3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,97 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1700403855,
+        "narHash": "sha256-Q0Uzjik9kUTN9pd/kp52XJi5kletBhy29ctBlAG+III=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c5678df521e1407884205fe3ce3cf1d7df297db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rpki-client-src": "rpki-client-src",
+        "rpki-openbsd-src": "rpki-openbsd-src",
+        "utils": "utils"
+      }
+    },
+    "rpki-client-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1697441637,
+        "narHash": "sha256-HWwuVMDi3zo2+okpt0J7yEOD+MhDw6fBQV31jj2Q0jo=",
+        "owner": "rpki-client",
+        "repo": "rpki-client-portable",
+        "rev": "aa554ab91add82bb68de00d323e02c9d20621aee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rpki-client",
+        "repo": "rpki-client-portable",
+        "rev": "aa554ab91add82bb68de00d323e02c9d20621aee",
+        "type": "github"
+      }
+    },
+    "rpki-openbsd-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1700133527,
+        "narHash": "sha256-UnCxtlQinmMOLR+EMrJz/PM6JxKATS2YXp4lvpVVtwk=",
+        "owner": "rpki-client",
+        "repo": "rpki-client-openbsd",
+        "rev": "082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rpki-client",
+        "repo": "rpki-client-openbsd",
+        "rev": "082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   inputs = {
     # We pin to a set nixpkgs version
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.11";
     # A lib to help build packages for multiple target systems
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version

--- a/flake.nix
+++ b/flake.nix
@@ -26,5 +26,9 @@
       rpki-client = import ./default.nix {inherit pkgs rpki-client-src rpki-openbsd-src;};
     in rec {
       defaultPackage = rpki-client;
+
+      # Run without cloning, must create a `cachedir` first to host fetched data
+      # nix run .# -- -d cachedir
+      apps.rpki-client = utils.lib.mkApp {drv = rpki-client;};
     });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,30 @@
+{
+  description = "RPKI Client v8.6";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    utils.url = "github:numtide/flake-utils";
+    rpki-client-src = {
+      url = "github:rpki-client/rpki-client-portable/aa554ab91add82bb68de00d323e02c9d20621aee"; # v8.6
+      flake = false;
+    };
+    rpki-openbsd-src = {
+      url = "github:rpki-client/rpki-client-openbsd/082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68"; # v8.6
+      flake = false;
+    };
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    utils,
+    rpki-client-src,
+    rpki-openbsd-src,
+  }:
+    utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+      rpki-client = import ./default.nix {inherit pkgs rpki-client-src rpki-openbsd-src;};
+    in rec {
+      defaultPackage = rpki-client;
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,22 @@
 {
   description = "RPKI Client v8.6";
 
+  # To build the package, run "nix build" in the current directory.
+  # This will build the rpki-client binary and put it in 'result/bin/'.
+
   inputs = {
+    # We pin to a set nixpkgs version
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
+    # A lib to help build packages for multiple target systems
     utils.url = "github:numtide/flake-utils";
+    # The RPKI portable client source, pinned to a specific version
     rpki-client-src = {
       url = "github:rpki-client/rpki-client-portable/aa554ab91add82bb68de00d323e02c9d20621aee"; # v8.6
       flake = false;
     };
+    # The openbsd shim of rpki-client-portable, which gets pulled into rpki-client at build time
+    # Since Nix can't fetch external sources (or access the Internet) at build time, we pull it in explicitly.
+    # See https://github.com/rpki-client/rpki-client-portable/blob/master/update.sh
     rpki-openbsd-src = {
       url = "github:rpki-client/rpki-client-openbsd/082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68"; # v8.6
       flake = false;
@@ -21,14 +30,16 @@
     rpki-client-src,
     rpki-openbsd-src,
   }:
+    # Read as: for each system, use nixpkgs and run the default.nix build instructions with these args.
     utils.lib.eachDefaultSystem (system: let
       pkgs = nixpkgs.legacyPackages.${system};
       rpki-client = import ./default.nix {inherit pkgs rpki-client-src rpki-openbsd-src;};
     in rec {
+      # This exposes a package under the namespace rpki-client.defaultPackage.<system>
       defaultPackage = rpki-client;
 
-      # Run without cloning, must create a `cachedir` first to host fetched data
-      # nix run .# -- -d cachedir
+      # To run locally without cloning this repo, create a `cachedir` locally to hold RPKI data.
+      # Then run "nix run github:fjahr/rpki-client-nix -- -d cachedir"
       apps.rpki-client = utils.lib.mkApp {drv = rpki-client;};
     });
 }


### PR DESCRIPTION
Making this a flake allows us to:
- pin inputs to ensure reproducibility. In this case, Nixpkgs pinned to 23.05, and rpki-client and the openbsd impl to specific commits that match `rpki-client` v8.6.
- reuse this specific set of tool versions in other flakes (the goal was kartograf). 
- Exposing a nix app allows someone with Nix installed and Flakes enabled to run `rpki-client` without cloning the repo: `nix run github:fjahr/rpki-client-nix -- -d cachedir` will run the client and use a local `cachedir` directory to store the data. Should be a good win for UX of running this tool. 