### PR TITLE
Update to version 9.1

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # build the package
 pkgs.stdenv.mkDerivation rec {
   name = "rpki-client";
-  version = "8.6";
+  version = "9.1";
 
   src = rpki-client-src;
 

--- a/flake.lock
+++ b/flake.lock
@@ -27,34 +27,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1697441637,
-        "narHash": "sha256-HWwuVMDi3zo2+okpt0J7yEOD+MhDw6fBQV31jj2Q0jo=",
+        "lastModified": 1719147915,
+        "narHash": "sha256-QM3rjH264vpW/3Cfjv1O0sjC+jrwRV8uJAYsLWZxRmE=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "aa554ab91add82bb68de00d323e02c9d20621aee",
+        "rev": "a8aadf11866008666e17c65da76132659942fe2c",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "aa554ab91add82bb68de00d323e02c9d20621aee",
+        "rev": "a8aadf11866008666e17c65da76132659942fe2c",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1700133527,
-        "narHash": "sha256-UnCxtlQinmMOLR+EMrJz/PM6JxKATS2YXp4lvpVVtwk=",
+        "lastModified": 1719126506,
+        "narHash": "sha256-YfOxKHbe5+H+Uv2ecQYcYX6gxk+ii2Zr9NSGuCElFwg=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68",
+        "rev": "a59ae351b4f900cf90b01e755118290047fcdb28",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68",
+        "rev": "a59ae351b4f900cf90b01e755118290047fcdb28",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,14 +11,14 @@
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version
     rpki-client-src = {
-      url = "github:rpki-client/rpki-client-portable/aa554ab91add82bb68de00d323e02c9d20621aee"; # v8.6
+      url = "github:rpki-client/rpki-client-portable/a8aadf11866008666e17c65da76132659942fe2c"; # v9.1
       flake = false;
     };
     # The openbsd shim of rpki-client-portable, which gets pulled into rpki-client at build time
     # Since Nix can't fetch external sources (or access the Internet) at build time, we pull it in explicitly.
     # See https://github.com/rpki-client/rpki-client-portable/blob/master/update.sh
     rpki-openbsd-src = {
-      url = "github:rpki-client/rpki-client-openbsd/082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68"; # v8.6
+      url = "github:rpki-client/rpki-client-openbsd/a59ae351b4f900cf90b01e755118290047fcdb28"; # v9.1
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "RPKI Client v8.6";
+  description = "RPKI Client v9.1";
 
   # To build the package, run "nix build" in the current directory.
   # This will build the rpki-client binary and put it in 'result/bin/'.

--- a/versions.nix
+++ b/versions.nix
@@ -1,5 +1,9 @@
 {version}: let
   versionHashes = {
+    "9.1" = {
+      portable = "a8aadf11866008666e17c65da76132659942fe2c";
+      openbsd = "a59ae351b4f900cf90b01e755118290047fcdb28";
+    };
     "8.6" = {
       portable = "aa554ab91add82bb68de00d323e02c9d20621aee";
       openbsd = "082ed00f2b1f8b1b578b2bc9eae84a5fc1923d68";


### PR DESCRIPTION
tested with kartograf 0.4.6 (only download part).

I'll backfill the missing version between 8.7 and 9.0 separately.

Closes https://github.com/fjahr/rpki-client-nix/issues/7