### PR TITLE
Bump to v9.3

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # build the package
 pkgs.stdenv.mkDerivation rec {
   name = "rpki-client";
-  version = "9.1";
+  version = "9.3";
 
   src = rpki-client-src;
 

--- a/flake.lock
+++ b/flake.lock
@@ -27,34 +27,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1719147915,
-        "narHash": "sha256-QM3rjH264vpW/3Cfjv1O0sjC+jrwRV8uJAYsLWZxRmE=",
+        "lastModified": 1726775911,
+        "narHash": "sha256-pyyBVLamtwUQnGzULrOoRgI92fnJPVuyGZhwG6N52q0=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "a8aadf11866008666e17c65da76132659942fe2c",
+        "rev": "12c58dcd8f61d18567fda0689ba64cb4b8c70a2d",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "a8aadf11866008666e17c65da76132659942fe2c",
+        "rev": "12c58dcd8f61d18567fda0689ba64cb4b8c70a2d",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1719126506,
-        "narHash": "sha256-YfOxKHbe5+H+Uv2ecQYcYX6gxk+ii2Zr9NSGuCElFwg=",
+        "lastModified": 1726753507,
+        "narHash": "sha256-MU/lO3Pa7aOs8xqB24cwlPfd4B2/aR8/BewEiqS/WVY=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "a59ae351b4f900cf90b01e755118290047fcdb28",
+        "rev": "dfa32b728c451dab0c97c854fbe23bc7b9be25ad",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "a59ae351b4f900cf90b01e755118290047fcdb28",
+        "rev": "dfa32b728c451dab0c97c854fbe23bc7b9be25ad",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "RPKI Client v9.1";
+  description = "RPKI Client";
 
   # To build the package, run "nix build" in the current directory.
   # This will build the rpki-client binary and put it in 'result/bin/'.
@@ -11,14 +11,14 @@
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version
     rpki-client-src = {
-      url = "github:rpki-client/rpki-client-portable/a8aadf11866008666e17c65da76132659942fe2c"; # v9.1
+      url = "github:rpki-client/rpki-client-portable/12c58dcd8f61d18567fda0689ba64cb4b8c70a2d"; # v9.3
       flake = false;
     };
     # The openbsd shim of rpki-client-portable, which gets pulled into rpki-client at build time
     # Since Nix can't fetch external sources (or access the Internet) at build time, we pull it in explicitly.
     # See https://github.com/rpki-client/rpki-client-portable/blob/master/update.sh
     rpki-openbsd-src = {
-      url = "github:rpki-client/rpki-client-openbsd/a59ae351b4f900cf90b01e755118290047fcdb28"; # v9.1
+      url = "github:rpki-client/rpki-client-openbsd/dfa32b728c451dab0c97c854fbe23bc7b9be25ad"; # v9.3
       flake = false;
     };
   };
@@ -39,7 +39,7 @@
       defaultPackage = rpki-client;
 
       # To run locally without cloning this repo, create a `cachedir` locally to hold RPKI data.
-      # Then run "nix run github:fjahr/rpki-client-nix -- -d cachedir"
+      # Then run "nix run github:asmap/rpki-client-nix -- -d cachedir"
       apps.rpki-client = utils.lib.mkApp {drv = rpki-client;};
     });
 }

--- a/versions.nix
+++ b/versions.nix
@@ -1,5 +1,9 @@
 {version}: let
   versionHashes = {
+    "9.3" = {
+      portable = "12c58dcd8f61d18567fda0689ba64cb4b8c70a2d";
+      openbsd = "dfa32b728c451dab0c97c854fbe23bc7b9be25ad";
+    };
     "9.1" = {
       portable = "a8aadf11866008666e17c65da76132659942fe2c";
       openbsd = "a59ae351b4f900cf90b01e755118290047fcdb28";


### PR DESCRIPTION
sync both portable and openbsd repos, update package version and flake.lock accordingly. 
Also updates to new repo URL in comment.