### PR TITLE
update to rpki-client v.9.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -27,34 +27,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1726775911,
-        "narHash": "sha256-pyyBVLamtwUQnGzULrOoRgI92fnJPVuyGZhwG6N52q0=",
+        "lastModified": 1736205605,
+        "narHash": "sha256-2/xe6BBZYo0IDYDFbPEdbCvYTdzQEb1Zl0BBQf/Z0aA=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "12c58dcd8f61d18567fda0689ba64cb4b8c70a2d",
+        "rev": "98954f463a60c1aa1f9c0c0de83370558ba452c7",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "12c58dcd8f61d18567fda0689ba64cb4b8c70a2d",
+        "rev": "98954f463a60c1aa1f9c0c0de83370558ba452c7",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1726753507,
-        "narHash": "sha256-MU/lO3Pa7aOs8xqB24cwlPfd4B2/aR8/BewEiqS/WVY=",
+        "lastModified": 1735901016,
+        "narHash": "sha256-+KexblAyPNHWwAGAdOzfWjZKXuwSqp12FrXFHuyFQnE=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "dfa32b728c451dab0c97c854fbe23bc7b9be25ad",
+        "rev": "27f8f58679530181c9e2f546046b714ad6f85b8c",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "dfa32b728c451dab0c97c854fbe23bc7b9be25ad",
+        "rev": "27f8f58679530181c9e2f546046b714ad6f85b8c",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727264057,
-        "narHash": "sha256-KQPI8CTTnB9CrJ7LrmLC4VWbKZfljEPBXOFGZFRpxao=",
+        "lastModified": 1736684107,
+        "narHash": "sha256-vH5mXxEvZeoGNkqKoCluhTGfoeXCZ1seYhC2pbMN0sg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "759537f06e6999e141588ff1c9be7f3a5c060106",
+        "rev": "635e887b48521e912a516625eee7df6cf0eba9c1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
 
   inputs = {
     # We pin to a set nixpkgs version
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
     # A lib to help build packages for multiple target systems
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version

--- a/flake.nix
+++ b/flake.nix
@@ -11,14 +11,14 @@
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version
     rpki-client-src = {
-      url = "github:rpki-client/rpki-client-portable/12c58dcd8f61d18567fda0689ba64cb4b8c70a2d"; # v9.3
+      url = "github:rpki-client/rpki-client-portable/98954f463a60c1aa1f9c0c0de83370558ba452c7"; # v9.4
       flake = false;
     };
     # The openbsd shim of rpki-client-portable, which gets pulled into rpki-client at build time
     # Since Nix can't fetch external sources (or access the Internet) at build time, we pull it in explicitly.
     # See https://github.com/rpki-client/rpki-client-portable/blob/master/update.sh
     rpki-openbsd-src = {
-      url = "github:rpki-client/rpki-client-openbsd/dfa32b728c451dab0c97c854fbe23bc7b9be25ad"; # v9.3
+      url = "github:rpki-client/rpki-client-openbsd/27f8f58679530181c9e2f546046b714ad6f85b8c"; # v9.4
       flake = false;
     };
   };


### PR DESCRIPTION
[v9.4 tag](https://github.com/rpki-client/rpki-client-portable/releases/tag/9.4)

Including a nixpkgs bump to 24.11 here.