### PR TITLE
Upgrade to rpki-client 9.5

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # build the package
 pkgs.stdenv.mkDerivation rec {
   name = "rpki-client";
-  version = "9.4";
+  version = "9.5";
 
   src = rpki-client-src;
 

--- a/flake.lock
+++ b/flake.lock
@@ -27,34 +27,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1736205605,
-        "narHash": "sha256-2/xe6BBZYo0IDYDFbPEdbCvYTdzQEb1Zl0BBQf/Z0aA=",
+        "lastModified": 1744153109,
+        "narHash": "sha256-BYfJwSVm+w7AZu34HD0XY5ORkxYNEtYDK6cn8h8WrQY=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "98954f463a60c1aa1f9c0c0de83370558ba452c7",
+        "rev": "36abf5dbc510ef98e5139f776806b723d3bcc705",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "98954f463a60c1aa1f9c0c0de83370558ba452c7",
+        "rev": "36abf5dbc510ef98e5139f776806b723d3bcc705",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1735901016,
-        "narHash": "sha256-+KexblAyPNHWwAGAdOzfWjZKXuwSqp12FrXFHuyFQnE=",
+        "lastModified": 1744104505,
+        "narHash": "sha256-OUfBK+mwOZ4KkvAWKFfrHU/c0iv2hmFisLOBg+Tfu34=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "27f8f58679530181c9e2f546046b714ad6f85b8c",
+        "rev": "f89bbe32af942a4dac8d2f9c13058ff63afa11d3",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "27f8f58679530181c9e2f546046b714ad6f85b8c",
+        "rev": "f89bbe32af942a4dac8d2f9c13058ff63afa11d3",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,14 +11,14 @@
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version
     rpki-client-src = {
-      url = "github:rpki-client/rpki-client-portable/98954f463a60c1aa1f9c0c0de83370558ba452c7"; # v9.4
+      url = "github:rpki-client/rpki-client-portable/36abf5dbc510ef98e5139f776806b723d3bcc705"; # v9.5
       flake = false;
     };
     # The openbsd shim of rpki-client-portable, which gets pulled into rpki-client at build time
     # Since Nix can't fetch external sources (or access the Internet) at build time, we pull it in explicitly.
     # See https://github.com/rpki-client/rpki-client-portable/blob/master/update.sh
     rpki-openbsd-src = {
-      url = "github:rpki-client/rpki-client-openbsd/27f8f58679530181c9e2f546046b714ad6f85b8c"; # v9.4
+      url = "github:rpki-client/rpki-client-openbsd/f89bbe32af942a4dac8d2f9c13058ff63afa11d3"; # v9.5
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,7 @@
       rpki-client = import ./default.nix {inherit pkgs rpki-client-src rpki-openbsd-src;};
     in rec {
       # This exposes a package under the namespace rpki-client.defaultPackage.<system>
-      defaultPackage = rpki-client;
+      packages.default = rpki-client;
 
       # To run locally without cloning this repo, create a `cachedir` locally to hold RPKI data.
       # Then run "nix run github:asmap/rpki-client-nix -- -d cachedir"

--- a/versions.nix
+++ b/versions.nix
@@ -1,5 +1,9 @@
 {version}: let
   versionHashes = {
+    "9.5" = {
+      portable = "36abf5dbc510ef98e5139f776806b723d3bcc705";
+      openbsd = "f89bbe32af942a4dac8d2f9c13058ff63afa11d3";
+    };
     "9.4" = {
       portable = "98954f463a60c1aa1f9c0c0de83370558ba452c7";
       openbsd = "27f8f58679530181c9e2f546046b714ad6f85b8c";


### PR DESCRIPTION
Upgrades to rpki-client 9.5. 
Tested entering developer env, running a build, and running the program.