### PR TITLE
update rpki-client to version 9.7

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # build the package
 pkgs.stdenv.mkDerivation rec {
   name = "rpki-client";
-  version = "9.6";
+  version = "9.7";
 
   src = rpki-client-src;
 

--- a/flake.lock
+++ b/flake.lock
@@ -27,34 +27,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1758369324,
-        "narHash": "sha256-emwYvo4sayLOBMLuqwk+HiJfyZ+UsVh4wZsk6ol0k1M=",
+        "lastModified": 1768329507,
+        "narHash": "sha256-2tZDPAinemEzpV+drJ3LYKG9YA6QmyWFlz+PcT7cwZc=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "5f446a23b2df68b821fdba4310399465e8e0247c",
+        "rev": "f2739829894cfab2711593e41a41dc79410f2d4b",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "5f446a23b2df68b821fdba4310399465e8e0247c",
+        "rev": "f2739829894cfab2711593e41a41dc79410f2d4b",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1758366358,
-        "narHash": "sha256-Zef7uxD0jh1xdqPh+7R0bMNSPHucfXkDDU0q2JC6kGg=",
+        "lastModified": 1768215410,
+        "narHash": "sha256-1H3naG9LjO5wEmEfy5lKt3toDuRlP0o/34jheky91sY=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "9729e89d562260b1102a76d3623d8757f20e01e3",
+        "rev": "a5a4b737770b3dc586330bbda9f0aeceebfcc961",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "9729e89d562260b1102a76d3623d8757f20e01e3",
+        "rev": "a5a4b737770b3dc586330bbda9f0aeceebfcc961",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,14 +11,14 @@
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version
     rpki-client-src = {
-      url = "github:rpki-client/rpki-client-portable/5f446a23b2df68b821fdba4310399465e8e0247c"; # v9.6
+      url = "github:rpki-client/rpki-client-portable/f2739829894cfab2711593e41a41dc79410f2d4b"; # v9.7
       flake = false;
     };
     # The openbsd shim of rpki-client-portable, which gets pulled into rpki-client at build time
     # Since Nix can't fetch external sources (or access the Internet) at build time, we pull it in explicitly.
     # See https://github.com/rpki-client/rpki-client-portable/blob/master/update.sh
     rpki-openbsd-src = {
-      url = "github:rpki-client/rpki-client-openbsd/9729e89d562260b1102a76d3623d8757f20e01e3"; # v9.6
+      url = "github:rpki-client/rpki-client-openbsd/a5a4b737770b3dc586330bbda9f0aeceebfcc961"; # v9.7
       flake = false;
     };
   };

--- a/versions.nix
+++ b/versions.nix
@@ -1,5 +1,9 @@
 {version}: let
   versionHashes = {
+    "9.7" = {
+      portable = "f2739829894cfab2711593e41a41dc79410f2d4b";
+      openbsd = "a5a4b737770b3dc586330bbda9f0aeceebfcc961";
+    };
     "9.6" = {
       portable = "5f446a23b2df68b821fdba4310399465e8e0247c";
       openbsd = "9729e89d562260b1102a76d3623d8757f20e01e3";


### PR DESCRIPTION
rpki-client 9.7 was [released](https://github.com/rpki-client/rpki-client-portable/releases/tag/9.7). 
The changes don't seem to affect our usage. I tested with running kartograf with this version and the run succeeded, and resulted in the same hash output for 9.6 and 9.7.