### PR TITLE
upgrade github runner install-nix action v22 -> v31

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: cachix/install-nix-action@v31
       with:
-        nix_path: nixpkgs=channel:nixos-23.11
+        nix_path: nixpkgs=channel:nixos-25.11
     - run: nix build


### PR DESCRIPTION
terribly far behind! My mistake for neglecting this.
install-nix-action v31 [release notes](https://github.com/cachix/install-nix-action/releases)