### PR TITLE
Bump to version 9.8

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 # build the package
 pkgs.stdenv.mkDerivation rec {
   name = "rpki-client";
-  version = "9.7";
+  version = "9.8";
 
   src = rpki-client-src;
 

--- a/flake.lock
+++ b/flake.lock
@@ -27,34 +27,34 @@
     "rpki-client-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768329507,
-        "narHash": "sha256-2tZDPAinemEzpV+drJ3LYKG9YA6QmyWFlz+PcT7cwZc=",
+        "lastModified": 1776199275,
+        "narHash": "sha256-PejvnEGr+K+g+vLgO+JroZXRAa1LUJUzCwDVm8AyScY=",
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "f2739829894cfab2711593e41a41dc79410f2d4b",
+        "rev": "15554f28842d7d9e6cc31eab5f95e36053b42f35",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-portable",
-        "rev": "f2739829894cfab2711593e41a41dc79410f2d4b",
+        "rev": "15554f28842d7d9e6cc31eab5f95e36053b42f35",
         "type": "github"
       }
     },
     "rpki-openbsd-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1768215410,
-        "narHash": "sha256-1H3naG9LjO5wEmEfy5lKt3toDuRlP0o/34jheky91sY=",
+        "lastModified": 1776072166,
+        "narHash": "sha256-sQfoPeWFKQXcaIgEgiCbBrdJ9s1pzXTqz25Y+OH/q4k=",
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "a5a4b737770b3dc586330bbda9f0aeceebfcc961",
+        "rev": "8aa0236d10a6c5e25fb282eb030069dae3d3abbe",
         "type": "github"
       },
       "original": {
         "owner": "rpki-client",
         "repo": "rpki-client-openbsd",
-        "rev": "a5a4b737770b3dc586330bbda9f0aeceebfcc961",
+        "rev": "8aa0236d10a6c5e25fb282eb030069dae3d3abbe",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,14 +11,14 @@
     utils.url = "github:numtide/flake-utils";
     # The RPKI portable client source, pinned to a specific version
     rpki-client-src = {
-      url = "github:rpki-client/rpki-client-portable/f2739829894cfab2711593e41a41dc79410f2d4b"; # v9.7
+      url = "github:rpki-client/rpki-client-portable/15554f28842d7d9e6cc31eab5f95e36053b42f35"; # v9.8
       flake = false;
     };
     # The openbsd shim of rpki-client-portable, which gets pulled into rpki-client at build time
     # Since Nix can't fetch external sources (or access the Internet) at build time, we pull it in explicitly.
     # See https://github.com/rpki-client/rpki-client-portable/blob/master/update.sh
     rpki-openbsd-src = {
-      url = "github:rpki-client/rpki-client-openbsd/a5a4b737770b3dc586330bbda9f0aeceebfcc961"; # v9.7
+      url = "github:rpki-client/rpki-client-openbsd/8aa0236d10a6c5e25fb282eb030069dae3d3abbe"; # v9.8
       flake = false;
     };
   };

--- a/versions.nix
+++ b/versions.nix
@@ -1,5 +1,9 @@
 {version}: let
   versionHashes = {
+    "9.8" = {
+      portable = "15554f28842d7d9e6cc31eab5f95e36053b42f35";
+      openbsd = "8aa0236d10a6c5e25fb282eb030069dae3d3abbe";
+    };
     "9.7" = {
       portable = "f2739829894cfab2711593e41a41dc79410f2d4b";
       openbsd = "a5a4b737770b3dc586330bbda9f0aeceebfcc961";


### PR DESCRIPTION
Came out a week ago, I already tested it pretty extensively.

https://ftp.openbsd.org/pub/OpenBSD/rpki-client/rpki-client-9.8.txt